### PR TITLE
fix titles, timezone

### DIFF
--- a/backend/utils/util.ts
+++ b/backend/utils/util.ts
@@ -11,7 +11,8 @@ export function isInsideArea(checkPoint: latlng, centerPoint: latlng, meters: nu
 
 // returns current time in hh:mm:ss format
 export function getCurrentTime() {
-  const today = new Date();
+  let today = new Date();
+  today = convertTZ(today, 'America/Vancouver');
   const hours = today.getHours();
   const minutes = today.getMinutes();
   const seconds = today.getSeconds();
@@ -23,7 +24,8 @@ export function getCurrentTime() {
 
 // returns todays date in dd-mm-yy format
 export function getTodaysDate() {
-  const today = new Date();
+  let today = new Date();
+  today = convertTZ(today, 'America/Vancouver');
   const day = today.getDate();
   const month = today.getMonth() + 1;
   const year = today.getFullYear();
@@ -33,7 +35,11 @@ export function getTodaysDate() {
   return dStr + '-' + mStr + '-' + yStr;
 }
 
+function convertTZ(date, tzString) {
+  return new Date((typeof date === 'string' ? new Date(date) : date).toLocaleString('en-US', { timeZone: tzString }));
+}
+
 export function delay(milliseconds: number) {
-  console.log("Delaying for "+milliseconds+" milliseconds");
-  return new Promise(resolve => setTimeout(resolve, milliseconds));
+  console.log('Delaying for ' + milliseconds + ' milliseconds');
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/frontend/utils/templates/detailedPartialTemplate.html
+++ b/frontend/utils/templates/detailedPartialTemplate.html
@@ -43,7 +43,7 @@
       <div class="row">
         <div class="col-sm text-right" style="text-align: right">{d.currentTime}</div>
       </div>
-      <h2 style="text-align: center; margin: 0.5rem">BC Registry: Site Registry</h2>
+      <h2 style="text-align: center; margin: 0.5rem">BC Registry and Online Services: Site Registry</h2>
       <p style="text-align: center; margin: 0">For: {d.account}</p>
       <!-- <p>Folio:</p> -->
 

--- a/frontend/utils/templates/nilPdfTemplate.html
+++ b/frontend/utils/templates/nilPdfTemplate.html
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="col-sm text-right">{d.currentTime}</div>
       </div>
-      <h2 style="text-align: center; margin: 0.5rem">BC Registry: Site Registry</h2>
+      <h2 style="text-align: center; margin: 0.5rem">BC Registry and Online Services: Site Registry</h2>
       <p style="text-align: center; margin: 0">For: {d.account}</p>
       <!-- <p>Folio:</p> -->
 

--- a/frontend/utils/templates/nilTemplate.html
+++ b/frontend/utils/templates/nilTemplate.html
@@ -22,7 +22,7 @@
       <div class="row">
         <div class="col-sm text-right">{d.currentTime}</div>
       </div>
-      <h2 style="text-align: center; margin: 0.5rem">BC Registry: Site Registry</h2>
+      <h2 style="text-align: center; margin: 0.5rem">BC Registry and Online Services: Site Registry</h2>
       <p style="text-align: center; margin: 0">For: {d.account}</p>
       <!-- <p>Folio:</p> -->
 

--- a/frontend/utils/templates/searchResultsPartialTemplate.html
+++ b/frontend/utils/templates/searchResultsPartialTemplate.html
@@ -45,7 +45,7 @@
       <div class="row">
         <div class="col-sm text-right">{d.currentTime}</div>
       </div>
-      <h2 style="text-align: center; margin: 0.5rem">BC Registry: Site Registry</h2>
+      <h2 style="text-align: center; margin: 0.5rem">BC Registry and Online Services: Site Registry</h2>
       <p style="text-align: center; margin: 0">For: {d.account}</p>
 
       <h3 style="text-align: center">{d.searchType} Search Results</h3>

--- a/frontend/utils/templates/synopsisTemplate.html
+++ b/frontend/utils/templates/synopsisTemplate.html
@@ -41,7 +41,7 @@
       <div class="row">
         <div class="col-sm text-right" style="text-align: right">{d.currentTime}</div>
       </div>
-      <h2 style="text-align: center; margin: 0.5rem">BC Registry: Site Registry</h2>
+      <h2 style="text-align: center; margin: 0.5rem">BC Registry and Online Services: Site Registry</h2>
       <p style="text-align: center; margin: 0">For: {d.account}</p>
       <!-- <p>Folio:</p> -->
 


### PR DESCRIPTION
- Changed the titles in all the reports from _BC Registry: Site Registry_ to _BC Registry and Online Service: Site Registry_
- Fixed the timezone issue
- Looked into the email time alignment issue, it formats fine on both test and my local version using Outlook. Since it uses HTML to format the email it could be the email service stripping that out somehow on some peoples machines but not others?