### PR TITLE
Generate the pdf/email before payment

### DIFF
--- a/frontend/public/js/util.js
+++ b/frontend/public/js/util.js
@@ -210,7 +210,13 @@ async function getPdfSynopsis() {
   fetch(`/bc-registry/download-pdf2/synopsis/${siteId}`, {
     method: 'GET',
   })
-    .then((res) => res.blob())
+    .then((res) => {
+      if (res.ok) {
+        return res.blob();
+      } else {
+        throw Error(res.status);
+      }
+    })
     .then((blob) => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -223,8 +229,12 @@ async function getPdfSynopsis() {
       hideSynDownloadSpinner();
       $(':button').prop('disabled', false);
     })
-    .catch(() => {
-      alert('Something went wrong');
+    .catch((err) => {
+      if (err.status == 400) {
+        alert('Failed to generate the report. You have not been charged.');
+      } else {
+        alert('Something went wrong');
+      }
       hideSynDownloadSpinner();
       $(':button').prop('disabled', false);
     });
@@ -236,7 +246,13 @@ async function getPdfDetailed() {
   fetch(`/bc-registry/download-pdf2/detailed/${siteId}`, {
     method: 'GET',
   })
-    .then((res) => res.blob())
+    .then((res) => {
+      if (res.ok) {
+        return res.blob();
+      } else {
+        throw res.status;
+      }
+    })
     .then((blob) => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
@@ -249,8 +265,12 @@ async function getPdfDetailed() {
       hideDetDownloadSpinner();
       $(':button').prop('disabled', false);
     })
-    .catch(() => {
-      alert('Something went wrong');
+    .catch((err) => {
+      if (err == 400) {
+        alert('Failed to generate the report. You have not been charged.');
+      } else {
+        alert('Something went wrong');
+      }
       hideDetDownloadSpinner();
       $(':button').prop('disabled', false);
     });
@@ -264,7 +284,13 @@ async function getPdf(siteId) {
     fetch(`/bc-registry/download-pdf/${reportType}/${siteId}`, {
       method: 'GET',
     })
-      .then((res) => res.blob())
+      .then((res) => {
+        if (res.ok) {
+          return res.blob();
+        } else {
+          throw res.status;
+        }
+      })
       .then((blob) => {
         const url = window.URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -277,8 +303,12 @@ async function getPdf(siteId) {
         hideDownloadSpinner(siteId);
         $(':button').prop('disabled', false);
       })
-      .catch(() => {
-        alert('Something went wrong');
+      .catch((err) => {
+        if (err == 400) {
+          alert('Failed to generate the report. You have not been charged.');
+        } else {
+          alert('Something went wrong');
+        }
         hideDownloadSpinner(siteId);
         $(':button').prop('disabled', false);
       });
@@ -297,21 +327,29 @@ async function emailPdf() {
       ? $('#reportEmailSelect').val()
       : $('#reportEmailInput').val();
     if (email !== null && email.match(/^\S+@\S+\.\S+$/) !== null) {
-      fetch(`/bc-registry/email-pdf/${reportType}/${encodeURI(email)}/${siteId}`, {
+      const response = await fetch(`/bc-registry/email-pdf/${reportType}/${encodeURI(email)}/${siteId}`, {
         method: 'GET',
         responseType: 'application/json',
       })
-        .then((res) => res.json())
-        .then((resJson) => {
-          alert(resJson.message);
-          hideReportEmailSpinner();
-          $(':button').prop('disabled', false);
+        .then((res) => {
+          if (res.ok) {
+            return res.json();
+          } else {
+            throw res.status;
+          }
         })
-        .catch(() => {
-          alert('Something went wrong');
+        .catch((err) => {
+          if (err == 400) {
+            alert('Failed to generate the report. You have not been charged.');
+          } else {
+            alert('Something went wrong');
+          }
           hideReportEmailSpinner();
           $(':button').prop('disabled', false);
         });
+      alert(response.message);
+      hideReportEmailSpinner();
+      $(':button').prop('disabled', false);
     } else {
       alert('Please enter a valid email');
       hideReportEmailSpinner();

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -285,6 +285,7 @@ export class BCRegistryService {
         })
         .catch((error) => {
           console.log(error.response);
+          throw error;
         });
       return response;
     } else {
@@ -356,10 +357,12 @@ export class BCRegistryService {
       const response = await axios(config)
         .then((response) => {
           console.log('Generated File');
+          console.log(response);
           return response.data;
         })
         .catch((error) => {
           console.log(error.response);
+          throw error;
         });
       return response;
     } else {
@@ -367,10 +370,8 @@ export class BCRegistryService {
     }
   }
 
-  // sends an email formatted with html that has all the report data
-  async emailHTML(reportType: string, email: string, siteId: string, name: string): Promise<string> {
+  async generateEmailHTML(reportType: string, siteId: string, name: string): Promise<any> {
     const cdogsToken = await this.getCdogsToken();
-    const chesToken = await this.getChesToken();
 
     const requestUrl =
       reportType == 'synopsis'
@@ -399,6 +400,12 @@ export class BCRegistryService {
       }
       htmlFile = await this.getHtml(siteData, documentTemplate, cdogsToken.toString());
     }
+    return htmlFile;
+  }
+
+  // sends an email formatted with html that has all the report data
+  async sendEmailHTML(reportType: string, email: string, siteId: string, htmlFile: string): Promise<string> {
+    const chesToken = await this.getChesToken();
 
     const rt = reportType == 'detailed' ? 'Detailed' : 'Synopsis';
     const data = JSON.stringify({
@@ -497,6 +504,7 @@ export class BCRegistryService {
       })
       .catch(function (error) {
         console.log(error);
+        throw error;
       });
 
     return htmlData;

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -357,7 +357,6 @@ export class BCRegistryService {
       const response = await axios(config)
         .then((response) => {
           console.log('Generated File');
-          console.log(response);
           return response.data;
         })
         .catch((error) => {


### PR DESCRIPTION
Changed the service to throw an error if cdogs fails to generate the pdf or html. This error is caught by the controller which in turn is caught by the frontend which will let the user know that there was an error and that they were not charged.

In order to properly handle throwing errors to the frontend, the way the controller handles returning values needed to be changed to use the response object to directly.

The flow is now: 
1. User requests to generate email/document
2. Nest generates the document, throwing an error if it gets one
3. If there are no errors, continue to the payment API
4. If the payment is successful, send the email or return the document.