### PR TITLE
email a pdf instead of the report as html

### DIFF
--- a/backend/src/srsites/srsites.service.ts
+++ b/backend/src/srsites/srsites.service.ts
@@ -389,6 +389,8 @@ export class SrsitesService {
   }
 
   async getDetailedReportData(siteId: string) {
+    const startTime = new Date().getTime();
+    console.log('Starting detailed report db section');
     const srevents = await this.sreventsRepository.findAndCount({ siteId: siteId });
     const srsitdoc = await this.srsitdocsRepository.findAndCount({ siteId: siteId });
     const srsitpars = await this.srsitparsRepository.findAndCount({ siteId: siteId });
@@ -524,7 +526,9 @@ export class SrsitesService {
       entry['qna'] = qna; // add the qna portion for each individual site profile
       profiles.push(entry);
     }
-
+    const endTime = new Date().getTime();
+    const timeTaken = (endTime - startTime) / 1000;
+    console.log(`Returning database data, time taken: ${timeTaken} seconds`);
     return {
       siteId: parseInt(siteId),
       account: 'user_account',

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -224,7 +224,7 @@ export class BCRegistryService {
 
   // builds the pdf report to be sent back to the frontend
   async getPdf(reportType: string, siteId: string, name: string): Promise<any> {
-    const authorizationToken = await this.getCdogsToken();
+    // const authorizationToken = await this.getCdogsToken();
 
     const requestUrl =
       reportType == 'synopsis'
@@ -245,6 +245,8 @@ export class BCRegistryService {
         this.httpService.get(requestUrl, requestConfig).pipe(map((response) => response.data))
       );
       data['account'] = name;
+      console.log('Received db data, starting pdf generation');
+      const startTime = new Date().getTime();
 
       let documentTemplate: string;
       if (reportType == 'detailed') {
@@ -252,7 +254,7 @@ export class BCRegistryService {
       } else {
         documentTemplate = this.buildSynopsisTemplate(data);
       }
-      const start = process.hrtime();
+
       const buff = Buffer.from(documentTemplate, 'base64');
       const text = buff.toString('utf-8');
 
@@ -268,9 +270,9 @@ export class BCRegistryService {
         //console.log('pdfBuffer: ' + pdfBuffer);
         returnBuffer = pdfBuffer;
       });
-      const end = process.hrtime(start);
-      const elapsedTime = (end[0] * 1000 + end[1] / 1000000) / 1000;
-      console.log(`End - ${elapsedTime}s`);
+      const endTime = new Date().getTime();
+      const timeTaken = (endTime - startTime) / 1000;
+      console.log(`Returning pdf buffer, time taken: ${timeTaken} seconds`);
       return returnBuffer;
       /*
       former CDAWGS method
@@ -344,6 +346,8 @@ export class BCRegistryService {
         console.log('caught error');
         return this.requestNilSiteIdPdf(parseInt(siteId).toString(), name);
       }
+      console.log('Received db data, starting pdf generation');
+      const startTime = new Date().getTime();
       data['account'] = name;
       let documentTemplate: string;
       if (reportType == 'detailed') {
@@ -367,6 +371,9 @@ export class BCRegistryService {
         //console.log('pdfBuffer: ' + pdfBuffer);
         returnBuffer = pdfBuffer;
       });
+      const endTime = new Date().getTime();
+      const timeTaken = (endTime - startTime) / 1000;
+      console.log(`Returning pdf buffer, time taken: ${timeTaken} seconds`);
       return returnBuffer;
       /*
       former CDAWGS method

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -320,7 +320,7 @@ export class BCRegistryService {
   }
 
   async getPdfSiteIdDirect(reportType: string, siteId: string, name: string): Promise<any> {
-    const authorizationToken = await this.getCdogsToken();
+    // const authorizationToken = await this.getCdogsToken();
 
     const requestUrl =
       reportType == 'synopsis'
@@ -454,8 +454,8 @@ export class BCRegistryService {
 
       //might be a more elegant way to do this
       let returnBuffer: any;
-      await html_to_pdf.generatePdf(file, options).then((pdfBuffer) => {
-        returnBuffer = pdfBuffer;
+      await html_to_pdf.generatePdf(file, options).then((p) => {
+        returnBuffer = p;
       });
       pdfBuffer = returnBuffer.toString('hex');
       // htmlFile = await this.getHtml(siteData, documentTemplate, cdogsToken.toString());

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -437,6 +437,7 @@ export class BCRegistryService {
       },
     };
 
+    let startTime: number;
     let documentTemplate: string;
     let pdfBuffer: string;
     if (requestUrl !== '') {
@@ -444,7 +445,8 @@ export class BCRegistryService {
         this.httpService.get(requestUrl, requestConfig).pipe(map((response) => response.data))
       );
       siteData['account'] = name;
-
+      console.log('Received db data, starting pdf generation');
+      startTime = new Date().getTime();
       if (reportType == 'detailed') {
         documentTemplate = this.buildDetailedTemplate(siteData);
       } else {
@@ -467,6 +469,9 @@ export class BCRegistryService {
       pdfBuffer = returnBuffer.toString('hex');
       // htmlFile = await this.getHtml(siteData, documentTemplate, cdogsToken.toString());
     }
+    const endTime = new Date().getTime();
+    const timeTaken = (endTime - startTime) / 1000;
+    console.log(`Returning pdf buffer, time taken: ${timeTaken} seconds`);
     return pdfBuffer;
   }
 

--- a/frontend/src/bc-registry/bc-registry.service.ts
+++ b/frontend/src/bc-registry/bc-registry.service.ts
@@ -416,7 +416,7 @@ export class BCRegistryService {
   }
 
   async generateEmailHTML(reportType: string, siteId: string, name: string): Promise<any> {
-    const cdogsToken = await this.getCdogsToken();
+    // const cdogsToken = await this.getCdogsToken();
 
     const requestUrl =
       reportType == 'synopsis'
@@ -431,7 +431,7 @@ export class BCRegistryService {
     };
 
     let documentTemplate: string;
-    let htmlFile: string;
+    let pdfBuffer: string;
     if (requestUrl !== '') {
       const siteData = await lastValueFrom(
         this.httpService.get(requestUrl, requestConfig).pipe(map((response) => response.data))
@@ -457,19 +457,19 @@ export class BCRegistryService {
       await html_to_pdf.generatePdf(file, options).then((pdfBuffer) => {
         returnBuffer = pdfBuffer;
       });
-      htmlFile = returnBuffer.toString('hex');
+      pdfBuffer = returnBuffer.toString('hex');
       // htmlFile = await this.getHtml(siteData, documentTemplate, cdogsToken.toString());
     }
-    return htmlFile;
+    return pdfBuffer;
   }
 
   // sends an email formatted with html that has all the report data
-  async sendEmailHTML(reportType: string, email: string, siteId: string, htmlFile: string): Promise<string> {
+  async sendEmailHTML(reportType: string, email: string, siteId: string, pdfBuffer: string): Promise<string> {
     const chesToken = await this.getChesToken();
     const rt = reportType == 'detailed' ? 'Detailed' : 'Synopsis';
     const data = JSON.stringify({
       attachments: [
-        { content: htmlFile, encoding: 'hex', filename: `${reportType}-report_siteid-${parseInt(siteId)}.pdf` },
+        { content: pdfBuffer, encoding: 'hex', filename: `${reportType}-report_siteid-${parseInt(siteId)}.pdf` },
       ],
       bodyType: 'html',
       body: `The ${rt} Report for Site ${parseInt(siteId)} is attached to this email.`,


### PR DESCRIPTION
Instead of emailing the report in the body of the email, attach it as a pdf.