### PR TITLE
fix: Update Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -24,8 +24,11 @@ RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 \
     fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
     wget libgbm-dev gnupg gnupg2 gnupg1
 
-# Install Chromium browser
-RUN apt-get install -y chromium-browser
+# Install Google Chrome for Puppeteer
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
+    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
+    apt-get update && \
+    apt-get install -y google-chrome-stable
 
 # Set up directories and adjust permissions
 RUN mkdir -p /root/.local/share/fonts \


### PR DESCRIPTION
The puppeteer upgrade requires chromium installed in a specific path.